### PR TITLE
Add support for --ignore-on-update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 tmp
 /ripoff
+/ripoff-export
 .DS_Store
 /export

--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ Currently, it attempts to export all data from all tables into a single ripoff f
 ripoff-export --exclude users --exclude audit_logs /path/to/export
 ```
 
+You can also use the `--ignore-on-update` flag to mark columns that should be ignored during subsequent imports (useful for timestamps that shouldn't change):
+
+```bash
+# Export all data but ignore created_at and updated_at columns during updates
+ripoff-export --ignore-on-update created_at --ignore-on-update updated_at /path/to/export
+```
+
+This adds a `~ignore_on_update` metadata field to rows containing the specified columns. During import, these columns will be included for new rows but ignored when updating existing rows, preventing timestamp-only changes from triggering unnecessary updates.
+
 In the future, additional flags may be added to allow you to include tables, add arbitrary `WHERE` conditions, modify the row id/key, export multiple files, or use existing templates.
 
 ## Installation

--- a/export_test.go
+++ b/export_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/lib/pq"
@@ -23,7 +24,7 @@ func runExportTestData(t *testing.T, ctx context.Context, tx pgx.Tx, testDir str
 	require.NoError(t, err)
 
 	// Generate new ripoff file.
-	ripoffFile, err := ExportToRipoff(ctx, tx, []string{})
+	ripoffFile, err := ExportToRipoff(ctx, tx, []string{}, []string{})
 	require.NoError(t, err)
 
 	// Ensure ripoff file matches expected output.
@@ -140,7 +141,7 @@ func TestExcludeFlag(t *testing.T) {
 
 	// Test 1: Exclude a single table
 	t.Run("Single exclude", func(t *testing.T) {
-		ripoffFile, err := ExportToRipoff(ctx, tx, []string{"exclude_me"})
+		ripoffFile, err := ExportToRipoff(ctx, tx, []string{"exclude_me"}, []string{})
 		require.NoError(t, err)
 
 		// Verify that ripoffFile.Rows contains rows from include_me but not exclude_me
@@ -199,7 +200,7 @@ func TestExcludeFlag(t *testing.T) {
 
 	// Test 2: Exclude multiple tables
 	t.Run("Multiple excludes", func(t *testing.T) {
-		ripoffFile, err := ExportToRipoff(ctx, tx, []string{"exclude_me", "also_exclude_me"})
+		ripoffFile, err := ExportToRipoff(ctx, tx, []string{"exclude_me", "also_exclude_me"}, []string{})
 		require.NoError(t, err)
 
 		// Verify that ripoffFile.Rows contains rows from include_me but not from the excluded tables
@@ -254,5 +255,179 @@ func TestExcludeFlag(t *testing.T) {
 		require.Equal(t, 2, includeCount, "Expected 2 rows from include_me table")
 		require.Equal(t, 0, excludeCount, "Expected 0 rows from exclude_me table")
 		require.Equal(t, 0, alsoExcludeCount, "Expected 0 rows from also_exclude_me table")
+	})
+}
+
+// TestIgnoreOnUpdateFlag tests that the ignore-on-update flag properly marks columns
+func TestIgnoreOnUpdateFlag(t *testing.T) {
+	envUrl := os.Getenv("RIPOFF_TEST_DATABASE_URL")
+	if envUrl == "" {
+		envUrl = "postgres:///ripoff-test-db"
+	}
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, envUrl)
+	if err != nil {
+		require.NoError(t, err)
+	}
+	defer conn.Close(ctx)
+
+	// Start a transaction that we'll roll back at the end
+	tx, err := conn.Begin(ctx)
+	require.NoError(t, err)
+	defer func() {
+		err := tx.Rollback(ctx)
+		require.NoError(t, err)
+	}()
+
+	// Create a table with columns including created_at and updated_at
+	_, err = tx.Exec(ctx, `
+		CREATE TABLE test_table (
+			id SERIAL PRIMARY KEY,
+			name TEXT,
+			created_at TIMESTAMP DEFAULT NOW(),
+			updated_at TIMESTAMP DEFAULT NOW(),
+			description TEXT
+		);
+		
+		INSERT INTO test_table (name, description) VALUES 
+			('test 1', 'first test'),
+			('test 2', 'second test');
+	`)
+	require.NoError(t, err)
+
+	// Test 1: Ignore created_at on update
+	t.Run("Ignore created_at on update", func(t *testing.T) {
+		ripoffFile, err := ExportToRipoff(ctx, tx, []string{}, []string{"created_at"})
+		require.NoError(t, err)
+
+		// Verify that ripoffFile.Rows contains rows with created_at but marked for ignore on update
+		rowCount := 0
+		for rowId, row := range ripoffFile.Rows {
+			if strings.HasPrefix(rowId, "test_table:") {
+				rowCount++
+				// Should have all columns including created_at
+				_, hasName := row["name"]
+				_, hasDescription := row["description"]
+				_, hasCreatedAt := row["created_at"]
+				_, hasUpdatedAt := row["updated_at"]
+
+				require.True(t, hasName, "Expected name column to be present")
+				require.True(t, hasDescription, "Expected description column to be present")
+				require.True(t, hasCreatedAt, "Expected created_at column to be present")
+				require.True(t, hasUpdatedAt, "Expected updated_at column to be present")
+
+				// Should have ignore-on-update metadata
+				ignoreOnUpdate, hasIgnoreOnUpdate := row["~ignore_on_update"]
+				require.True(t, hasIgnoreOnUpdate, "Expected ~ignore_on_update metadata to be present")
+				
+				ignoreList, ok := ignoreOnUpdate.([]string)
+				require.True(t, ok, "Expected ~ignore_on_update to be a slice of strings")
+				require.Equal(t, []string{"created_at"}, ignoreList, "Expected created_at to be in ignore list")
+			}
+		}
+		require.Equal(t, 2, rowCount, "Expected 2 rows from test_table")
+	})
+
+	// Test 2: Ignore multiple columns on update
+	t.Run("Ignore multiple columns on update", func(t *testing.T) {
+		ripoffFile, err := ExportToRipoff(ctx, tx, []string{}, []string{"created_at", "updated_at"})
+		require.NoError(t, err)
+
+		// Verify that ripoffFile.Rows contains rows with both timestamp columns marked for ignore
+		rowCount := 0
+		for rowId, row := range ripoffFile.Rows {
+			if strings.HasPrefix(rowId, "test_table:") {
+				rowCount++
+				// Should have all columns including both timestamp columns
+				_, hasName := row["name"]
+				_, hasDescription := row["description"]
+				_, hasCreatedAt := row["created_at"]
+				_, hasUpdatedAt := row["updated_at"]
+
+				require.True(t, hasName, "Expected name column to be present")
+				require.True(t, hasDescription, "Expected description column to be present")
+				require.True(t, hasCreatedAt, "Expected created_at column to be present")
+				require.True(t, hasUpdatedAt, "Expected updated_at column to be present")
+
+				// Should have ignore-on-update metadata with both columns
+				ignoreOnUpdate, hasIgnoreOnUpdate := row["~ignore_on_update"]
+				require.True(t, hasIgnoreOnUpdate, "Expected ~ignore_on_update metadata to be present")
+				
+				ignoreList, ok := ignoreOnUpdate.([]string)
+				require.True(t, ok, "Expected ~ignore_on_update to be a slice of strings")
+				require.ElementsMatch(t, []string{"created_at", "updated_at"}, ignoreList, "Expected both timestamp columns to be in ignore list")
+			}
+		}
+		require.Equal(t, 2, rowCount, "Expected 2 rows from test_table")
+	})
+
+	// Test 3: No ignore-on-update metadata when no columns specified
+	t.Run("No ignore metadata when no columns specified", func(t *testing.T) {
+		ripoffFile, err := ExportToRipoff(ctx, tx, []string{}, []string{})
+		require.NoError(t, err)
+
+		// Verify that ripoffFile.Rows contains rows without ignore-on-update metadata
+		rowCount := 0
+		for rowId, row := range ripoffFile.Rows {
+			if strings.HasPrefix(rowId, "test_table:") {
+				rowCount++
+				// Should NOT have ignore-on-update metadata
+				_, hasIgnoreOnUpdate := row["~ignore_on_update"]
+				require.False(t, hasIgnoreOnUpdate, "Expected no ~ignore_on_update metadata when no columns specified")
+			}
+		}
+		require.Equal(t, 2, rowCount, "Expected 2 rows from test_table")
+	})
+
+	// Test 4: Verify ignore-on-update preserves existing values during re-export
+	t.Run("Preserve existing values on re-export", func(t *testing.T) {
+		// First export with ignore-on-update flags
+		ripoffFile1, err := ExportToRipoff(ctx, tx, []string{}, []string{"created_at", "updated_at"})
+		require.NoError(t, err)
+
+		// Get the original timestamp values from first export
+		var originalCreatedAt, originalUpdatedAt string
+		for rowId, row := range ripoffFile1.Rows {
+			if strings.HasPrefix(rowId, "test_table:") {
+				originalCreatedAt = row["created_at"].(string)
+				originalUpdatedAt = row["updated_at"].(string)
+				break
+			}
+		}
+
+		// Simulate time passing and database changes
+		// Add a small delay to ensure different timestamps
+		time.Sleep(10 * time.Millisecond)
+		// Update the database with new timestamp values
+		_, err = tx.Exec(ctx, "UPDATE test_table SET updated_at = NOW() + INTERVAL '1 second' WHERE id = 1")
+		require.NoError(t, err)
+
+		// Second export with same ignore-on-update flags
+		// This should preserve the original timestamp values, not use the new database values
+		ripoffFile2, err := ExportToRipoffWithExisting(ctx, tx, []string{}, []string{"created_at", "updated_at"}, &ripoffFile1)
+		require.NoError(t, err)
+
+		// Check that the timestamp values are preserved from first export
+		for rowId, row := range ripoffFile2.Rows {
+			if strings.HasPrefix(rowId, "test_table:") {
+				currentCreatedAt := row["created_at"].(string)
+				currentUpdatedAt := row["updated_at"].(string)
+				
+				t.Logf("Original created_at: %s, Current created_at: %s", originalCreatedAt, currentCreatedAt)
+				t.Logf("Original updated_at: %s, Current updated_at: %s", originalUpdatedAt, currentUpdatedAt)
+				
+				// These assertions should pass with the new logic
+				require.Equal(t, originalCreatedAt, currentCreatedAt, "created_at should be preserved from original export")
+				require.Equal(t, originalUpdatedAt, currentUpdatedAt, "updated_at should be preserved from original export")
+				
+				// Verify the metadata is still present
+				ignoreOnUpdate, hasIgnoreOnUpdate := row["~ignore_on_update"]
+				require.True(t, hasIgnoreOnUpdate, "Expected ~ignore_on_update metadata to be present")
+				ignoreList, ok := ignoreOnUpdate.([]string)
+				require.True(t, ok, "Expected ~ignore_on_update to be a slice of strings")
+				require.ElementsMatch(t, []string{"created_at", "updated_at"}, ignoreList, "Expected both timestamps in ignore list")
+				break
+			}
+		}
 	})
 }


### PR DESCRIPTION
I think the README update is a decent description of what I'm trying to achieve here: 

```You can also use the `--ignore-on-update` flag to mark columns that should be ignored during subsequent imports (useful for timestamps that shouldn't change):

```bash
# Export all data but ignore created_at and updated_at columns during updates
ripoff-export --ignore-on-update created_at --ignore-on-update updated_at /path/to/export
```

This adds a `~ignore_on_update` metadata field to rows containing the specified columns. During import, these columns will be included for new rows but ignored when updating existing rows, preventing timestamp-only changes from triggering unnecessary updates.```

Generally, when using ripoff I tend to do the following: 

- Work on a feature in my normal way. 
- When a feature is finished, I want to persist the locally created DB state as my known "good" state for future development. 
- run `ripoff-export` and do any manual tweaks that are needed. 
- In the future, I can run `ripoff db/fake-data` to reset to my known good state for development. 

One annoying thing (that this PR attempts to solve) is that I use `created_at/updated_at` timestamps on every table in my database so each `ripoff-export` invocation touches every table definition in my saved dataset. 

To keep the diffs more minimal, `--ignore-on-update` provides a way to skip specifically named columns (that, in this case repeat across tables). 